### PR TITLE
Fix severe bug in distance matrix -- found/fixed by Bernd Fritzke.

### DIFF
--- a/R/kmeanspp.R
+++ b/R/kmeanspp.R
@@ -62,14 +62,17 @@ kmeanspp <- function(data, k = 2,
       center_ids[1:2] = start
     }
     for (ii in 2:kk) { # the plus-plus step in kmeans
-      if (ndim == 1){
-        dists <- apply(cbind(data[center_ids, ]), 1, 
-                       function(center) {rowSums((data - center)^2)})
-      } else {
-        dists <- apply(data[center_ids, ], 1, 
-                       function(center) {rowSums((data - center)^2)})
+      if (ndim == 1) {
+          dists <- apply(cbind(data[center_ids, ]), 1, 
+            function(center) {
+              rowSums((data - rep(center,each=nrow(data) ) )^2) # fixed
+            })
       }
-      probs <- apply(dists, 1, min)
+      else {
+          dists <- apply(data[center_ids, ], 1, function(center) {
+            rowSums((data - rep(center,each=nrow(data) ) )^2) # fixed
+          })
+      }      probs <- apply(dists, 1, min)
       probs[center_ids] <- 0
       center_ids[ii] <- sample.int(num.samples, 1, prob = probs)
     }


### PR DESCRIPTION
In Nov. 2021, Bernd Fritzke [reported & fixed](https://www.mail-archive.com/r-help@r-project.org/msg263971.html) a severe bug in the distance matrix calculation.  The bug resulted in poor performance equivalent to naive init (rather than k-means++).

Bernd reports:
> In its current form, the results were much worse than those of Hartigan-Wong (the default for k-means in the stats 
package) for all test problems I tried. However, after fixing the bug, kmeanspp found better results than Hartigan-Wong for all those problems.

In summary:
> The bug concerns a distance computation which should be a matrix of distances of all data vectors and all current codebook vectors, but is not. The code and an example illustrating the problem is shown below. Basically, to subtract a vector from a matrix, one has to convert the vector into a matrix where all rows are just copies of the vector. ... The fix is trivial.


See also this [post by Paul Harrison](https://logarithmic.net/pfh-files/blog/01618034037/k-means-better.html), who also noticed sub-optimal results.  When I [compared these to scikit-learn](https://ctwardy.micro.blog/2021/06/10/on-kmeans-clustering.html), I discovered the results were as if the inits were still naive (random).  

Bernd's analysis would explain that -- and appears to fix it.